### PR TITLE
fix: close and persistence

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -142,4 +142,5 @@ class ElasticSearchIndexer(Executor):
 
     def close(self) -> None:
         super().close()
+        self._index.sync()
         del self._index

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 import time
 
+import numpy as np
+from docarray import Document, DocumentArray
 import pytest
 from elasticsearch import Elasticsearch
 
@@ -18,4 +20,18 @@ def docker_compose():
     yield
     os.system(
         f"docker-compose -f {compose_yml} --project-directory . down --remove-orphans"
+    )
+
+
+@pytest.fixture(scope='module')
+def docs():
+    return DocumentArray(
+        [
+            Document(id='doc1', embedding=np.random.rand(128)),
+            Document(id='doc2', embedding=np.random.rand(128)),
+            Document(id='doc3', embedding=np.random.rand(128)),
+            Document(id='doc4', embedding=np.random.rand(128)),
+            Document(id='doc5', embedding=np.random.rand(128)),
+            Document(id='doc6', embedding=np.random.rand(128)),
+        ]
     )

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,5 +1,5 @@
 def assert_document_arrays_equal(arr1, arr2):
-    # assert arr1[0]
+    assert arr1[0]
     assert len(arr1) == len(arr2)
     for d1, d2 in zip(arr1, arr2):
         assert d1.id == d2.id

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,8 @@
+def assert_document_arrays_equal(arr1, arr2):
+    # assert arr1[0]
+    assert len(arr1) == len(arr2)
+    for d1, d2 in zip(arr1, arr2):
+        assert d1.id == d2.id
+        assert d1.content == d2.content
+        assert d1.chunks == d2.chunks
+        assert d1.matches == d2.matches

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -48,15 +48,13 @@ def test_reload_keep_state(docker_compose):
         assert len(first_search[0].matches) == len(second_search[0].matches)
 
 
-def test_persistence(docker_compose):
-    docs = DocumentArray([Document(id=f'doc{i}', embedding=np.random.rand(3)) for i in range(6)])
+def test_persistence(docs, docker_compose):
     f = Flow().add(
         uses=ElasticSearchIndexer,
-        uses_with={'index_name': 'test3', 'n_dim': 2, 'distance': 'l2_norm'},
+        uses_with={'index_name': 'test3', 'distance': 'l2_norm'},
     )
     with f:
         f.index(docs)
-
     indexer = ElasticSearchIndexer(index_name='test3', distance='l2_norm')
     assert_document_arrays_equal(indexer._index, docs)
     indexer.close()

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -10,19 +10,6 @@ from helper import assert_document_arrays_equal
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 compose_yml = os.path.abspath(os.path.join(cur_dir, '../docker-compose.yml'))
 
-@pytest.fixture
-def docs():
-    return DocumentArray(
-        [
-            Document(id='doc1', embedding=np.random.rand(128)),
-            Document(id='doc2', embedding=np.random.rand(128)),
-            Document(id='doc3', embedding=np.random.rand(128)),
-            Document(id='doc4', embedding=np.random.rand(128)),
-            Document(id='doc5', embedding=np.random.rand(128)),
-            Document(id='doc6', embedding=np.random.rand(128)),
-        ]
-    )
-
 
 @pytest.fixture
 def update_docs():


### PR DESCRIPTION
This PR will fix the `close()` function and `test_persistence` for ElasticSearch indexer.
The `test_persistence` before is partly skipped by right `len` but empty content.

- [x] add sync to close()
- [x] fix test_persistence