### PR TITLE
feat: disable list like behaviour 

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -57,6 +57,7 @@ class ElasticSearchIndexer(Executor):
                 'ef_construction': ef_construction,
                 'm': m,
                 'columns': columns,
+                'list_like': False,
             },
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-docarray[elasticsearch]>=0.13.21
+docarray[elasticsearch]>=0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docarray[elasticsearch]>=0.19.0
-git+https://github.com/jina-ai/jina.git@master
+jina>=3.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docarray[elasticsearch]>=0.19.0
--e https://github.com/jina-ai/jina.git@branch/master
+git+https://github.com/jina-ai/jina.git@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 docarray[elasticsearch]>=0.19.0
-jina>=3.11.1
+jina>=3.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 docarray[elasticsearch]>=0.19.0
+-e https://github.com/jina-ai/jina.git@branch/master

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
-git+https://github.com/jina-ai/jina.git@master
+jina>=3.11.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
-jina>=3.11.1
+jina>=3.11.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 pytest==7.1.2
+docarray>=0.19.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
+-e https://github.com/jina-ai/jina.git@branch/master

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
 pytest==7.1.2
 docarray>=0.19.0
--e https://github.com/jina-ai/jina.git@branch/master
+git+https://github.com/jina-ai/jina.git@master

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -123,11 +123,8 @@ def test_persistence(docs, docker_compose):
     assert_document_arrays_equal(indexer2._index, docs)
 
 
-@pytest.mark.parametrize(
-    'metric, metric_name',
-    [('l2_norm', 'euclid_similarity'), ('cosine', 'cosine_similarity')],
-)
-def test_search(metric, metric_name, docs, docker_compose):
+@pytest.mark.parametrize('metric', ['l2_norm', 'cosine'])
+def test_search(metric, docs, docker_compose):
     # test general/normal case
     indexer = ElasticSearchIndexer(index_name='test7', distance=metric)
     indexer.index(docs)
@@ -136,7 +133,7 @@ def test_search(metric, metric_name, docs, docker_compose):
 
     for doc in query:
         similarities = [
-            t[metric_name].value for t in doc.matches[:, 'scores']
+            t['score'].value for t in doc.matches[:, 'scores']
         ]
         assert sorted(similarities, reverse=True) == similarities
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -78,7 +78,6 @@ def test_update(docs, update_docs, docker_compose):
 
     # update first doc
     indexer.update(update_docs)
-    assert indexer._index[0].id == 'doc1'
     assert indexer._index['doc1'].text == 'modified'
 
 


### PR DESCRIPTION
Previously, a list_like parameter has been added to the storage backends, this parameter we now want to introduce to the ElasticSearchIndexer.
This way, the list-like behaviour can be disabled the the [performance issues regarding the list-like behaviour](https://docarray.jina.ai/advanced/document-store/#performance-issue-caused-by-list-like-structure) removed ().

Solving this issue: https://github.com/docarray/docarray/issues/802